### PR TITLE
Fix duplicate nuxt config sections

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -91,23 +91,6 @@ export default defineNuxtConfig({
     },
     skipSettingLocaleOnNavigate: false,
   },
-  css: ["~/assets/css/main.css"],
-  modules: [
-    "@nuxt/fonts",
-    "@nuxt/icon",
-    "@pinia/nuxt",
-    "@vueuse/sound/nuxt",
-    "@vueuse/nuxt",
-    "@nuxt/ui",
-    'pinia-plugin-persistedstate/nuxt',
-    "nuxt-og-image",
-    'nuxt-umami',
-  ],
-  sound: {
-    sounds: {
-      scan: true,
-    },
-  },
   runtimeConfig: {
     appwriteApiKey: process.env.APPWRITE_API_KEY,
     appwriteEndpoint: process.env.APPWRITE_ENDPOINT,


### PR DESCRIPTION
## Summary
- deduplicate `modules`, `css` and `sound` sections in `nuxt.config.ts`
- keep single configuration block at top of file

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408980ea60832e97dc85c45afee610