### PR TITLE
Fix SSR appwrite usage

### DIFF
--- a/components/admin/CardManager.vue
+++ b/components/admin/CardManager.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
 import { getAppwrite } from '~/utils/appwrite'
 import { Query } from 'appwrite'
+import type { Databases } from 'appwrite'
 import { useNotifications } from '~/composables/useNotifications'
 import { ref, computed, watch, onMounted } from 'vue'
 import { watchDebounced } from '@vueuse/core'
 import stringSimilarity from 'string-similarity'
 import type { RadioGroupItem, RadioGroupValue } from '@nuxt/ui'
 
-const { databases } = getAppwrite()
+let databases: Databases | undefined
+if (import.meta.client) {
+  ({ databases } = getAppwrite())
+}
 const config = useRuntimeConfig()
 const { notify } = useNotifications()
 
@@ -92,7 +96,8 @@ const CARD_COLLECTION = computed(() => CARD_COLLECTIONS[cardType.value])
 
 // Fetch available card packs on mount
 onMounted(async () => {
-	try {
+        if (!databases) return
+        try {
 		// First get total count of cards
 		const countResult = await databases.listDocuments(DB_ID, CARD_COLLECTION.value, [Query.limit(1)])
 		const totalCards = countResult.total
@@ -129,7 +134,8 @@ onMounted(async () => {
 
 // Watch for card type changes to reload packs
 watch(cardType, async () => {
-	try {
+        if (!databases) return
+        try {
 		// First get total count of cards
 		const countResult = await databases.listDocuments(DB_ID, CARD_COLLECTION.value, [Query.limit(1)])
 		const totalCards = countResult.total
@@ -167,7 +173,8 @@ watch(cardType, async () => {
 
 // Fetch cards
 const fetchCards = async () => {
-	loading.value = true
+        if (!databases) return
+        loading.value = true
 
 	try {
 		// First get total count of cards with filters applied

--- a/components/admin/LobbyMonitor.vue
+++ b/components/admin/LobbyMonitor.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, computed } from 'vue'
 import { getAppwrite } from '~/utils/appwrite'
 import { Query } from 'appwrite'
+import type { Databases } from 'appwrite'
 import { useNotifications } from '~/composables/useNotifications'
 import type { GameSettings } from '~/types/gamesettings'
 import type { Lobby } from '~/types/lobby'
@@ -11,7 +12,10 @@ type LobbyWithName = Lobby & {
   lobbyName?: string | null
 }
 
-const { databases } = getAppwrite()
+let databases: Databases | undefined
+if (import.meta.client) {
+  ({ databases } = getAppwrite())
+}
 const config = useRuntimeConfig()
 const { notify } = useNotifications()
 
@@ -59,7 +63,8 @@ const totalPages = computed(() => {
 })
 
 const checkActiveLobbies = async () => {
-	loading.value = true
+        if (!databases) return
+        loading.value = true
 	try {
 		// 1. Fetch all lobbies, ordered by creation date
 		const lobbyRes = await databases.listDocuments(DB_ID, LOBBY_COL, [

--- a/components/game/GameSettings.vue
+++ b/components/game/GameSettings.vue
@@ -76,10 +76,14 @@ import {useGameSettings} from '~/composables/useGameSettings'
 import {useNotifications} from '~/composables/useNotifications'
 import {getAppwrite} from '~/utils/appwrite'
 import {Query} from 'appwrite'
+import type { Databases } from 'appwrite'
 
 const { t } = useI18n()
 const { notify } = useNotifications()
-const { databases } = getAppwrite()
+let databases: Databases | undefined
+if (import.meta.client) {
+  ({ databases } = getAppwrite())
+}
 const config = useRuntimeConfig()
 
 const props = defineProps<{
@@ -116,7 +120,8 @@ const CARD_COLLECTIONS = {
 
 // Fetch available card packs on mount
 onMounted(async () => {
-	loadingPacks.value = true
+        if (!databases) return
+        loadingPacks.value = true
 	try {
 		// First get total count of black cards
 		const blackCountResult = await databases.listDocuments(DB_ID, CARD_COLLECTIONS.black, [Query.limit(1)])

--- a/composables/useAdminCheck.ts
+++ b/composables/useAdminCheck.ts
@@ -20,8 +20,11 @@ export const useAdminCheck = async (): Promise<boolean> => {
     }
 
     try {
-        // console.log('[useAdminCheck] Getting Appwrite teams service')
-        const { teams } = getAppwrite()
+        let teams
+        if (import.meta.client) {
+            ({ teams } = getAppwrite())
+        }
+        if (!teams) return false
         const config = useRuntimeConfig()
         const ADMIN_TEAM_ID = config.public.appwriteAdminTeamId as string
         // console.log('[useAdminCheck] Admin team ID:', ADMIN_TEAM_ID)

--- a/composables/useGameCards.ts
+++ b/composables/useGameCards.ts
@@ -4,7 +4,11 @@ import type {GameCards, PlayerHand} from '~/types/gamecards';
 import type {CardId, PlayerId} from '~/types/game';
 
 export const useGameCards = () => {
-  const { databases, client } = getAppwrite();
+  let databases: ReturnType<typeof getAppwrite>['databases'] | undefined
+  let client: ReturnType<typeof getAppwrite>['client'] | undefined
+  if (import.meta.client) {
+    ({ databases, client } = getAppwrite())
+  }
   const config = useRuntimeConfig();
 
   // Reactive state
@@ -76,6 +80,7 @@ export const useGameCards = () => {
 
   // Subscribe to real-time updates for game cards
   const subscribeToGameCards = (lobbyId: string, onUpdate?: (cards: GameCards) => void) => {
+    if (!client) return () => {}
     // First fetch the initial data
     fetchGameCards(lobbyId);
 

--- a/composables/useGameEngine.ts
+++ b/composables/useGameEngine.ts
@@ -6,7 +6,10 @@ import { getRandomInt } from '~/composables/useCrypto';
 
 
 export const useGameEngine = () => {
-    const { databases } = getAppwrite();
+    let databases: ReturnType<typeof getAppwrite>['databases'] | undefined
+    if (import.meta.client) {
+        ({ databases } = getAppwrite())
+    }
     const config = useRuntimeConfig();
 
     const shuffle = <T>(array: T[]): T[] => {

--- a/composables/useGameSettings.ts
+++ b/composables/useGameSettings.ts
@@ -5,13 +5,17 @@ import { getAppwrite } from '~/utils/appwrite';
 import type { GameSettings } from '~/types/gamesettings';
 
 export function useGameSettings() {
-    const { databases } = getAppwrite();
+    let databases: ReturnType<typeof getAppwrite>['databases'] | undefined
+    if (import.meta.client) {
+        ({ databases } = getAppwrite())
+    }
     const settings = ref<GameSettings | null>(null);
     const loading = ref(false);
     const error = ref<Error | null>(null);
 
     // Get game settings for a lobby
     const getGameSettings = async (lobbyId: string): Promise<GameSettings | null> => {
+        if (!databases) return null
         const config = useRuntimeConfig();
         loading.value = true;
         error.value = null;
@@ -82,6 +86,7 @@ export function useGameSettings() {
 
     // Create default game settings
     const createDefaultGameSettings = async (lobbyId: string, lobbyName: string, hostUserId?: string, options?: { isPrivate?: boolean, password?: string }): Promise<GameSettings> => {
+        if (!databases) throw new Error('Appwrite not initialized')
         const config = useRuntimeConfig();
 
         // First, check if settings already exist for this lobby
@@ -160,6 +165,7 @@ export function useGameSettings() {
 
     // Save game settings
     const saveGameSettings = async (lobbyId: string, newSettings: GameSettings, hostUserId?: string): Promise<GameSettings> => {
+        if (!databases) throw new Error('Appwrite not initialized')
         const config = useRuntimeConfig();
 
         try {

--- a/pages/game/index.vue
+++ b/pages/game/index.vue
@@ -47,13 +47,17 @@ import {useLobby} from '~/composables/useLobby'
 import {useUserAccess} from '~/composables/useUserUtils'
 import { getAppwrite } from '~/utils/appwrite'
 import { Query } from 'appwrite'
+import type { Databases } from 'appwrite'
 import { useGetPlayerName } from '~/composables/useGetPlayerName'
 import type { GameSettings } from '~/types/gamesettings'
 import type { Lobby } from '~/types/lobby'
 import { useI18n } from 'vue-i18n'
 const { t } = useI18n()
 
-const { databases } = getAppwrite()
+let databases: Databases | undefined
+if (import.meta.client) {
+  ({ databases } = getAppwrite())
+}
 const config = useRuntimeConfig()
 const showJoin = ref(false)
 const showCreate = ref(false)
@@ -76,7 +80,8 @@ const {showIfAuthenticated} = useUserAccess()
 const hostNames = ref<Record<string, string>>({})
 
 const fetchPublicLobbies = async () => {
-	try {
+        if (!databases) return
+        try {
 		const lobbyRes = await databases.listDocuments<Lobby>(DB_ID, LOBBY_COL, [
 			Query.equal('status', 'waiting'),
 			Query.orderDesc('$createdAt'),


### PR DESCRIPTION
## Summary
- avoid using Appwrite SDK during server-side rendering in several composables
- guard subscriptions when databases/client are unavailable

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e5656eb0832e93427ba0df3e33f4