### PR TITLE
Fix Issue #7: Prevent host from creating more than one lobby

### DIFF
--- a/composables/useLobby.ts
+++ b/composables/useLobby.ts
@@ -129,6 +129,12 @@ export const useLobby = () => {
         const { databases } = getAppwrite();
         const config = getConfig();
 
+        // Check if the user already has an active lobby
+        const existingLobby = await getActiveLobbyForUser(hostUserId);
+        if (existingLobby) {
+            throw new Error('You already have an active lobby. Please finish or leave that lobby before creating a new one.');
+        }
+
         // Generate a cryptographically secure random lobby code
         const randomValue = getRandomHexString(4);
         const lobbyCode = randomValue.substring(0, 6).toUpperCase();


### PR DESCRIPTION


This PR addresses issue #7 by adding a check in the `createLobby` function to prevent users from creating multiple lobbies.

Changes made:
1. Added a check using the existing `getActiveLobbyForUser` function to verify if a user already has an active lobby before allowing them to create another one.
2. If a user attempts to create a new lobby while they already have an active one, they will receive an error message instructing them to finish or leave their current lobby.

This ensures that hosts can only manage one lobby at a time, which helps maintain game integrity and prevents potential conflicts.

