### PR TITLE
feat: add share image component

### DIFF
--- a/components/game/RoundEndOverlay.vue
+++ b/components/game/RoundEndOverlay.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
 import { useGameActions } from '~/composables/useGameActions';
+import ShareImage from '~/components/game/ShareImage.vue';
 
 const { t } = useI18n();
 
@@ -286,27 +287,38 @@ watch(() => props.startTime, () => {
 
    <!-- Display prompt card and winning card if available -->
    <div v-if="effectiveWinningCards && Array.isArray(effectiveWinningCards) && effectiveWinningCards.length > 0" class="flex justify-center mb-6 mt-4">
-   	<div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-   		<!-- Display the prompt card on the left -->
-   		<div v-if="props.blackCard" class="mb-4 sm:mb-0">
-   			<BlackCard
-   				:card-id="props.blackCard.id"
-   				:text="props.blackCard.text"
-   				:num-pick="props.blackCard.pick"
-   				:flipped="false"
-   			/>
-   		</div>
-   		<!-- Display the winning submission on the right -->
-   		<div class="flex flex-wrap items-center justify-center gap-2">
-   			<WhiteCard
-   				v-for="cardId in effectiveWinningCards"
-   				:key="cardId"
-   				:cardId="cardId"
-   				:is-winner="true"
-   				:flipped="false"
-   			/>
-   		</div>
-   	</div>
+        <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+                <!-- Display the prompt card on the left -->
+                <div v-if="props.blackCard" class="mb-4 sm:mb-0">
+                        <BlackCard
+                                :card-id="props.blackCard.id"
+                                :text="props.blackCard.text"
+                                :num-pick="props.blackCard.pick"
+                                :flipped="false"
+                        />
+                </div>
+                <!-- Display the winning submission on the right -->
+                <div class="flex flex-wrap items-center justify-center gap-2">
+                        <WhiteCard
+                                v-for="cardId in effectiveWinningCards"
+                                :key="cardId"
+                                :cardId="cardId"
+                                :is-winner="true"
+                                :flipped="false"
+                        />
+                </div>
+        </div>
+        <div
+                class="flex justify-center mt-4"
+                v-if="props.blackCard && effectiveWinningCards.length"
+        >
+                <ShareImage
+                        :black-card="props.blackCard"
+                        :white-card-ids="effectiveWinningCards"
+                >
+                        Share
+                </ShareImage>
+        </div>
    </div>
    <!-- Fallback message if no winning cards are available -->
    <div v-else class="text-gray-500 text-sm">

--- a/components/game/ShareImage.vue
+++ b/components/game/ShareImage.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { toPng } from 'html-to-image';
+import BlackCard from '~/components/game/BlackCard.vue';
+import WhiteCard from '~/components/game/WhiteCard.vue';
+import { ref } from 'vue';
+
+const props = defineProps<{
+  blackCard?: { id?: string; text: string; pick?: number };
+  whiteCardIds: string[];
+}>();
+
+const captureRef = ref<HTMLElement | null>(null);
+
+async function download() {
+  if (!captureRef.value) return;
+  try {
+    const dataUrl = await toPng(captureRef.value, { pixelRatio: 2 });
+    const link = document.createElement('a');
+    link.href = dataUrl;
+    link.download = 'unfit.png';
+    link.click();
+  } catch (e) {
+    console.error('Failed to generate image', e);
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div class="fixed -left-[9999px] -top-[9999px]">
+      <div ref="captureRef" class="p-4 flex gap-4 bg-slate-800">
+        <BlackCard
+          v-if="blackCard"
+          :card-id="blackCard.id"
+          :text="blackCard.text"
+          :num-pick="blackCard.pick"
+        />
+        <div class="flex flex-wrap gap-2">
+          <WhiteCard
+            v-for="id in whiteCardIds"
+            :key="id"
+            :card-id="id"
+            :is-winner="true"
+            :flipped="false"
+          />
+        </div>
+      </div>
+    </div>
+    <UButton @click="download" color="primary" variant="subtle">
+      <slot>Share</slot>
+    </UButton>
+  </div>
+</template>

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "dompurify": "^3.2.6",
     "dotenv": "^16.5.0",
     "gsap": "^3.13.0",
+    "html-to-image": "^1.11.11",
     "lodash-es": "^4.17.21",
     "markdown-it": "^14.1.0",
     "mespeak": "^2.0.2",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -69,26 +69,33 @@
 		</div>
 		<div class="flex flex-col items-center mt-8">
 			<ClientOnly>
-				<UButtonGroup>
-					<UButton
-							:loading="isFetching"
-							class="text-xl py-2 px-4 cursor-pointer font-['Bebas_Neue']"
-							color="secondary" icon="i-solar-layers-minimalistic-bold-duotone" variant="subtle"
-							@click="handleTryMeClick"
-					>
-						{{ t('try_me') }}
-					</UButton>
-					<UButton
-							:disabled="isSpeaking"
-							:loading="isSpeaking"
-							class="text-xl py-2 px-4 cursor-pointer font-['Bebas_Neue']"
-							color="primary" icon="i-solar-user-speak-bold-duotone" variant="subtle"
-							@click="handleSpeakClick"
-					/>
-				</UButtonGroup>
-			</ClientOnly>
-		</div>
-	</div>
+                                <UButtonGroup>
+                                        <UButton
+                                                        :loading="isFetching"
+                                                        class="text-xl py-2 px-4 cursor-pointer font-['Bebas_Neue']"
+                                                        color="secondary" icon="i-solar-layers-minimalistic-bold-duotone" variant="subtle"
+                                                        @click="handleTryMeClick"
+                                        >
+                                                {{ t('try_me') }}
+                                        </UButton>
+                                        <UButton
+                                                        :disabled="isSpeaking"
+                                                        :loading="isSpeaking"
+                                                        class="text-xl py-2 px-4 cursor-pointer font-['Bebas_Neue']"
+                                                        color="primary" icon="i-solar-user-speak-bold-duotone" variant="subtle"
+                                                        @click="handleSpeakClick"
+                                        />
+                                        <ShareImage
+                                                        v-if="blackCard && whiteCard"
+                                                        :black-card="{ id: blackCard.$id, text: blackCard.text, pick: blackCard.pick }"
+                                                        :white-card-ids="[whiteCard.$id]"
+                                        >
+                                                Share
+                                        </ShareImage>
+                                </UButtonGroup>
+                        </ClientOnly>
+                </div>
+        </div>
 
 </template>
 
@@ -102,6 +109,7 @@ import { useI18n } from 'vue-i18n';
 import { useUserPrefsStore } from '@/stores/userPrefsStore';
 import { TTS_PROVIDERS, getProviderFromVoiceId } from '~/constants/ttsProviders';
 import {useUserStore} from "~/stores/userStore";
+import ShareImage from '~/components/game/ShareImage.vue';
 type TTSProvider = 'browser' | 'elevenlabs' | 'openai';
 
 const { proxy: { event } } = useScriptRybbitAnalytics()


### PR DESCRIPTION
## Summary
- add ShareImage component using html-to-image
- integrate share button into round end overlay
- enable sharing random combinations on the homepage

## Testing
- `pnpm test` *(fails: useRuntimeConfig is not defined, unresolved components, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b7936dd81c832ebd30e84ac36544a5